### PR TITLE
Make sure the value is always an Oembed object

### DIFF
--- a/FieldtypeOembed.module
+++ b/FieldtypeOembed.module
@@ -112,35 +112,32 @@ class FieldtypeOembed extends FieldtypeURL implements Module, ConfigurableModule
 	 * Given a raw value from DB
 	 * @param Page $page
 	 * @param Field $field
-	 * @param array|int|string $value
+	 * @param array $value
 	 * @return string
 	 */
-	public function ___wakeupValue(Page $page, Field $field, $value): string {
+	public function ___wakeupValue(Page $page, Field $field, $value): Oembed {
 		$oembedObj = $this->getBlankValue($page, $field);
 		$oembedData = json_decode($value['oembed'],JSON_OBJECT_AS_ARRAY);
 		if(is_array($oembedData)) $oembedObj->setArray($oembedData);
 
-		$page->setQuietly('_oembedObj' . $field->name, $oembedObj);
-		$page->setQuietly('_oembedExpires' . $field->name, $this->datetime->date('ts', $value['expires']));
+		if(!empty($value['data']) && $oembedObj->get('empty')) {
+			$oembedObj->set('url', $value['data']);
+		}
 
-		return $value['data'];
+		return $oembedObj;
 	}
 
 	/**
 	 * For storage in DB
 	 * @param Page $page
 	 * @param Field $field
-	 * @param array|float|int|object|string $value
+	 * @param Oembed $value
 	 * @return array
 	 */
 	public function ___sleepValue(Page $page, Field $field, $value): array {
-
-		// get raw data
-		if($value instanceof Oembed) $value = $page->getUnformatted($field->name);
-
-		$oembedData = $this->fetch($value);
+		$oembedData = $this->fetch($value->url);
 		return [
-			'data' => $value,
+			'data' => $value->url,
 			'oembed' => json_encode($oembedData, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
 			'expires' => $oembedData
 				? $this->datetime->date(self::MysqlDatetimeFormat, time() + $field->get('cacheTime'))
@@ -149,24 +146,49 @@ class FieldtypeOembed extends FieldtypeURL implements Module, ConfigurableModule
 	}
 
 	/**
+	 * Given a value, make it clean and of the correct type for storage within a Page
+	 *
+	 * @param Page $page
+	 * @param Field $field
+	 * @param Oembed $value
+	 * @return Oembed
+	 *
+	 */
+	public function sanitizeValue(Page $page, Field $field, $value) {
+		if(!$value instanceof Oembed) {
+			$oembed = $this->getBlankValue($page, $field);
+			$value = $this->sanitizer->url($value, array(
+				'allowRelative' => false,
+				'allowIDN' => $field->get("allowIDN") ? true : false,
+				'stripQuotes' => $field->get("allowQuotes") ? false : true,
+			));
+			if(!empty($value)) {
+				$oembed->set("url", $value);
+			}
+			return $oembed;
+		}
+		return $value;
+	}
+
+	/**
 	 * Format a value for front-end output
 	 * @param Page $page
 	 * @param Field $field
-	 * @param string $value
+	 * @param Oembed $value
 	 * @return Oembed
 	 */
 	public function ___formatValue(Page $page, Field $field, $value) {
-		return $page->get('_oembedObj' . $field->name);
+		return $value;
 	}
 
 	/**
 	 * @param Page $page
 	 * @param Field $field
-	 * @param $value
+	 * @param Oembed $value
 	 * @return bool
 	 */
 	public function isDeleteValue(Page $page, Field $field, $value): bool {
-		return empty($value);
+		return empty($value->url);
 	}
 
 	/**
@@ -400,18 +422,18 @@ class FieldtypeOembed extends FieldtypeURL implements Module, ConfigurableModule
 	 * @return void
 	 */
 	public function refreshOembedData($event = null) {
-		foreach(wire()->fields->findByType($this) as $field) {
+		foreach($this->fields->findByType($this) as $field) {
 			$expiredPages = $this->pages->findMany("{$field->name}.expires<now,check_access=0,include=hidden");
 			foreach($expiredPages as $expiredPage) {
 				try {
 					$expiredPage->of(false);
 					$expiredPage->save($field->name);
-					wire()->log->save(
+					$this->log->save(
 						self::refreshLog,
 						'Refresh Oembed Data From URL ' . $expiredPage->getUnformatted($field->name)
 					);
 				} catch(\Exception $exception) {
-					wire()->log->save(
+					$this->log->save(
 						self::refreshLog,
 						'Error in field ' . $expiredPage->getUnformatted($field->name) . ': ' . $exception->getMessage()
 					);

--- a/FieldtypeOembedConfig.php
+++ b/FieldtypeOembedConfig.php
@@ -50,7 +50,7 @@ class FieldtypeOembedConfig extends ModuleConfig
 		if(!empty($this->customProviders)) {
 			$customProviders = json_decode($this->customProviders,JSON_OBJECT_AS_ARRAY);
 			if(!is_array($customProviders)) {
-				wire()->error('Invalid JSON in field Custom Providers (JSON)');
+				$this->error('Invalid JSON in field Custom Providers (JSON)');
 			}
 		}
 

--- a/InputfieldOembed.module
+++ b/InputfieldOembed.module
@@ -40,14 +40,15 @@ class InputfieldOembed extends InputfieldURL {
 
 		$this->config->styles->add($this->config->urls->InputfieldOembed . "InputfieldOembed.css");
 		$fieldtype = $this->get('hasField');
+		$value = $this->get('value');
 
 		if(
 			$fieldtype &&
 			$fieldtype->type instanceof FieldtypeOembed &&
-			!empty($this->get('value')) &&
-			$this->hasPage instanceof Page
+			!empty($value) &&
+			$value->url
 		) {
-			$preview = $this->oembedPreview($this->hasPage->getFormatted($fieldtype->name));
+			$preview = $this->oembedPreview($value);
 			if($preview) {
 				$this->appendMarkup($preview);
 			}
@@ -62,6 +63,13 @@ class InputfieldOembed extends InputfieldURL {
 		}
 
 		return parent::___render();
+	}
+
+	protected function setAttributeValue($value) {
+		if($value instanceof Oembed) {	
+			$value->url = parent::setAttributeValue($value->url);
+		}
+		return $value;
 	}
 
 	/**

--- a/InputfieldOembed.module
+++ b/InputfieldOembed.module
@@ -40,15 +40,15 @@ class InputfieldOembed extends InputfieldURL {
 
 		$this->config->styles->add($this->config->urls->InputfieldOembed . "InputfieldOembed.css");
 		$fieldtype = $this->get('hasField');
-		$value = $this->get('value');
+		$oembed = $this->get('oembed');
 
 		if(
 			$fieldtype &&
 			$fieldtype->type instanceof FieldtypeOembed &&
-			!empty($value) &&
-			$value->url
+			!empty($oembed) &&
+			$oembed->url
 		) {
-			$preview = $this->oembedPreview($value);
+			$preview = $this->oembedPreview($oembed);
 			if($preview) {
 				$this->appendMarkup($preview);
 			}
@@ -67,9 +67,10 @@ class InputfieldOembed extends InputfieldURL {
 
 	protected function setAttributeValue($value) {
 		if($value instanceof Oembed) {	
-			$value->url = parent::setAttributeValue($value->url);
+			$this->set('oembed', $value);
+			$value = $value->url;
 		}
-		return $value;
+		return parent::setAttributeValue($value);
 	}
 
 	/**

--- a/Oembed.php
+++ b/Oembed.php
@@ -31,6 +31,7 @@ class Oembed extends WireData {
 		$this->field = $field;
 
 		$this->set('empty', true);
+		$this->set('url', '');
 	}
 
 	/**
@@ -44,7 +45,7 @@ class Oembed extends WireData {
 	public function set($key, $value) {
 
 		// declare as valid
-		if($key !== 'empty') $this->set('empty', false);
+		if($key !== 'empty' && $key !== 'url') $this->set('empty', false);
 
 		// date
 		if($key === 'date') $value = $value ? wireDate('c', $value) : '';
@@ -63,7 +64,7 @@ class Oembed extends WireData {
 	 * @return string
 	 */
 	public function __toString() {
-		return $this->render();
+		return $this->get("url");
 	}
 }
 

--- a/Oembed.php
+++ b/Oembed.php
@@ -64,7 +64,7 @@ class Oembed extends WireData {
 	 * @return string
 	 */
 	public function __toString() {
-		return $this->get("url");
+		return $this->render();
 	}
 }
 


### PR DESCRIPTION
This PR removes the "_oembedObj" property and instead make sure the value is always an Oembed object with at least the properties `empty` and `url` (what’s input in the field).

The key functions (among other bits) to make this work with an InputfieldURL descendant were `FieldtypeOembed::sanitizeValue` and `InputfieldOembed::setAttributeValue`.

This resolves the issue with Pagefile/image’s custom field mentioned [here](https://github.com/neuerituale/FieldtypeOembed/issues/5).

Of course I invite you to examine first and also try before merging to make sure I didn’t miss something.

(I’m doing this first as I wanted to add the ability for the field to hold a [local copy of the thumbnail](https://processwire.com/talk/topic/25538-fieldtypeoembed/?do=findComment&comment=233744), unless you’re also working on this?)